### PR TITLE
Compensate delays due to image processing

### DIFF
--- a/trifinger_rl_datasets/sim_env.py
+++ b/trifinger_rl_datasets/sim_env.py
@@ -447,7 +447,7 @@ class SimTriFingerCubeEnv(gym.Env):
             # Also take time into account that might have already passed
             # while the observation was processed.
             # print("t_now - self.t_obs: ", t_now - self.t_obs)
-            print(t_now - self.t_obs)
+            print(f"{t_now - self.t_obs},")
             for _ in range(self.obs_action_delay - (t_now - self.t_obs)):
                 self._append_desired_action(robot_action)
 

--- a/trifinger_rl_datasets/sim_env.py
+++ b/trifinger_rl_datasets/sim_env.py
@@ -446,6 +446,7 @@ class SimTriFingerCubeEnv(gym.Env):
             # user time to evaluate the policy.
             # Also take time into account that might have already passed
             # while the observation was processed.
+            print("t_now - self.t_obs: ", t_now - self.t_obs)
             for _ in range(self.obs_action_delay - (t_now - self.t_obs)):
                 self._append_desired_action(robot_action)
 

--- a/trifinger_rl_datasets/sim_env.py
+++ b/trifinger_rl_datasets/sim_env.py
@@ -446,7 +446,8 @@ class SimTriFingerCubeEnv(gym.Env):
             # user time to evaluate the policy.
             # Also take time into account that might have already passed
             # while the observation was processed.
-            print("t_now - self.t_obs: ", t_now - self.t_obs)
+            # print("t_now - self.t_obs: ", t_now - self.t_obs)
+            print(t_now - self.t_obs)
             for _ in range(self.obs_action_delay - (t_now - self.t_obs)):
                 self._append_desired_action(robot_action)
 

--- a/trifinger_rl_datasets/sim_env.py
+++ b/trifinger_rl_datasets/sim_env.py
@@ -446,7 +446,7 @@ class SimTriFingerCubeEnv(gym.Env):
             # user time to evaluate the policy.
             # Also take time into account that might have already passed
             # while the observation was processed.
-            for _ in range(self.obs_action_delay - (t_now - self.t_obs)):
+            for _ in range(max(self.obs_action_delay - (t_now - self.t_obs), 0)):
                 self._append_desired_action(robot_action)
 
         return observation, reward, False, truncated, info

--- a/trifinger_rl_datasets/sim_env.py
+++ b/trifinger_rl_datasets/sim_env.py
@@ -440,10 +440,13 @@ class SimTriFingerCubeEnv(gym.Env):
         truncated = self.step_count >= self.episode_length
 
         if not truncated and preappend_actions:
+            t_now = self.platform.get_current_timeindex()
             # Append action to action queue of robot for as many time
             # steps as the obs_action_delay dictates. This gives the
             # user time to evaluate the policy.
-            for _ in range(self.obs_action_delay):
+            # Also take time into account that might have already passed
+            # while the observation was processed.
+            for _ in range(self.obs_action_delay - (t_now - self.t_obs)):
                 self._append_desired_action(robot_action)
 
         return observation, reward, False, truncated, info

--- a/trifinger_rl_datasets/sim_env.py
+++ b/trifinger_rl_datasets/sim_env.py
@@ -572,6 +572,7 @@ class SimTriFingerCubeEnv(gym.Env):
             "confidence": np.array([object_observation.confidence], dtype=np.float32),
         }
         if self.image_obs:
+            time_0 = time()
             if len(camera_observation.cameras[0].image.shape) == 2:
                 # images from real platform have to be debayered
                 images = np.array([cv2.cvtColor(cam.image, cv2.COLOR_BAYER_BG2RGB) for cam in camera_observation.cameras])
@@ -582,6 +583,7 @@ class SimTriFingerCubeEnv(gym.Env):
             # convert to channel first
             images = np.transpose(images, (0, 3, 1, 2))
             camera_obs_processed["images"] = images
+            print("time to process images: ", time() - time_0)
         if self.keypoint_obs:
             camera_obs_processed["object_keypoints"] = get_keypoints_from_pose(
                 object_observation

--- a/trifinger_rl_datasets/sim_env.py
+++ b/trifinger_rl_datasets/sim_env.py
@@ -446,8 +446,6 @@ class SimTriFingerCubeEnv(gym.Env):
             # user time to evaluate the policy.
             # Also take time into account that might have already passed
             # while the observation was processed.
-            # print("t_now - self.t_obs: ", t_now - self.t_obs)
-            print(f"{t_now - self.t_obs},")
             for _ in range(self.obs_action_delay - (t_now - self.t_obs)):
                 self._append_desired_action(robot_action)
 
@@ -572,7 +570,6 @@ class SimTriFingerCubeEnv(gym.Env):
             "confidence": np.array([object_observation.confidence], dtype=np.float32),
         }
         if self.image_obs:
-            time_0 = time()
             if len(camera_observation.cameras[0].image.shape) == 2:
                 # images from real platform have to be debayered
                 images = np.array([cv2.cvtColor(cam.image, cv2.COLOR_BAYER_BG2RGB) for cam in camera_observation.cameras])
@@ -583,7 +580,6 @@ class SimTriFingerCubeEnv(gym.Env):
             # convert to channel first
             images = np.transpose(images, (0, 3, 1, 2))
             camera_obs_processed["images"] = images
-            print("time to process images: ", time() - time_0)
         if self.keypoint_obs:
             camera_obs_processed["object_keypoints"] = get_keypoints_from_pose(
                 object_observation


### PR DESCRIPTION
When creating the observation takes several milliseconds then compensate by pre-appending fewer actions to keep the control loop running at the right frequency.